### PR TITLE
feat(ci): enable `pip` caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
             python-version: "${{ matrix.python-version }}"
+            cache: "pip"
+            cache-dependency-path: '**/requirements*.txt'
       - name: Run CI tests
         run: bash test.sh
         shell: bash


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Set the `cache` and `cache-dependency-path` argument of `actions/setup-python` to enable `pip` caching.