### PR TITLE
fix error when not using multiple devices

### DIFF
--- a/kfac_jax/_src/optimizer.py
+++ b/kfac_jax/_src/optimizer.py
@@ -964,6 +964,8 @@ class Optimizer(utils.WithStagedMethods):
     batch_size = self._batch_size_extractor(func_args[-1])
     if self.multi_device:
       total_batch_size = batch_size * jax.device_count()
+    else:
+      total_batch_size = batch_size
 
     # Update data seen and step counter
     state.data_seen = state.data_seen + total_batch_size


### PR DESCRIPTION
Currently there will be an error for `total_batch_size` not defined when `multi_device=False`. fix it by setting `total_batch_size = batch_size` for single devices